### PR TITLE
Improve workflow ordering

### DIFF
--- a/.github/workflows/build-push-artifacts.yml
+++ b/.github/workflows/build-push-artifacts.yml
@@ -8,95 +8,16 @@ on:
       - master
     tags:
       - "*"
-  # Also allow publication to be done via a workflow call
-  # In this case, the chart version is returned as an output
-  workflow_call:
-    inputs:
-      ref:
-        type: string
-        description: The ref to build.
-        required: true
-    outputs:
-      chart-version:
-        description: The chart version that was published
-        value: ${{ jobs.build_push_chart.outputs.chart-version }}
 
 jobs:
-  build_push_images:
-    name: Build and push images
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - component: chat
-          - component: image-analysis
-    permissions:
-      contents: read
-      id-token: write         # needed for signing the images with GitHub OIDC Token
-      packages: write         # required for pushing container images
-      security-events: write  # required for pushing SARIF files
-    steps:
-      - name: Check out the repository
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.ref || github.ref }}
+  publish_images:
+    uses: ./.github/workflows/build-push-images.yml
+    with:
+      ref: ${{ inputs.ref || github.ref }}
+    secrets: inherit
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get SemVer version for current commit
-        id: semver
-        uses: azimuth-cloud/github-actions/semver@master
-
-      - name: Calculate metadata for image
-        id: image-meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/stackhpc/azimuth-llm-${{ matrix.component }}-ui
-          # Produce the branch name or tag and the SHA as tags
-          tags: |
-            type=ref,event=branch
-            type=ref,event=tag
-            type=raw,value=${{ steps.semver.outputs.short-sha }}
-
-      - name: Build and push image
-        uses: azimuth-cloud/github-actions/docker-multiarch-build-push@master
-        with:
-          cache-key: ${{ matrix.component }}
-          context: ./web-apps/
-          file: ./web-apps/${{ matrix.component }}/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.image-meta.outputs.tags }}
-          labels: ${{ steps.image-meta.outputs.labels }}
-
-  build_push_chart:
-    name: Build and push Helm chart
-    runs-on: ubuntu-latest
-    # Only build and push the chart if the images built successfully
-    needs: [build_push_images]
-    outputs:
-      chart-version: ${{ steps.semver.outputs.version }}
-    steps:
-      - name: Check out the repository
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-          # This is important for the semver action to work correctly
-          # when determining the number of commits since the last tag
-          fetch-depth: 0
-
-      - name: Get SemVer version for current commit
-        id: semver
-        uses: azimuth-cloud/github-actions/semver@master
-
-      - name: Publish Helm charts
-        uses: azimuth-cloud/github-actions/helm-publish@master
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          version: ${{ steps.semver.outputs.version }}
-          app-version: ${{ steps.semver.outputs.short-sha }}
+  publish_charts:
+    uses: ./.github/workflows/build-push-charts.yml
+    with:
+      ref: ${{ inputs.ref || github.ref }}
+    secrets: inherit

--- a/.github/workflows/build-push-artifacts.yml
+++ b/.github/workflows/build-push-artifacts.yml
@@ -13,11 +13,11 @@ jobs:
   publish_images:
     uses: ./.github/workflows/build-push-images.yml
     with:
-      ref: ${{ inputs.ref || github.ref }}
+      ref: ${{ github.ref }}
     secrets: inherit
 
   publish_charts:
     uses: ./.github/workflows/build-push-charts.yml
     with:
-      ref: ${{ inputs.ref || github.ref }}
+      ref: ${{ github.ref }}
     secrets: inherit

--- a/.github/workflows/build-push-charts.yml
+++ b/.github/workflows/build-push-charts.yml
@@ -1,5 +1,5 @@
 # Adapted from https://github.com/stackhpc/azimuth/blob/master/.github/workflows/build-push-artifacts.yaml
-name: Publish artifacts
+name: Publish Helm charts
 
 on:
   workflow_call:
@@ -24,7 +24,7 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ inputs.ref }}
           # This is important for the semver action to work correctly
           # when determining the number of commits since the last tag
           fetch-depth: 0

--- a/.github/workflows/build-push-charts.yml
+++ b/.github/workflows/build-push-charts.yml
@@ -1,0 +1,41 @@
+# Adapted from https://github.com/stackhpc/azimuth/blob/master/.github/workflows/build-push-artifacts.yaml
+name: Publish artifacts
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        type: string
+        description: The ref to build.
+        required: true
+    outputs:
+      chart-version:
+        description: The chart version that was published
+        value: ${{ jobs.build_push_chart.outputs.chart-version }}
+
+jobs:
+  build_push_charts:
+    name: Build and push Helm charts
+    runs-on: ubuntu-latest
+    # Only build and push the chart if the images built successfully
+    outputs:
+      chart-version: ${{ steps.semver.outputs.version }}
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          # This is important for the semver action to work correctly
+          # when determining the number of commits since the last tag
+          fetch-depth: 0
+
+      - name: Get SemVer version for current commit
+        id: semver
+        uses: azimuth-cloud/github-actions/semver@master
+
+      - name: Publish Helm charts
+        uses: azimuth-cloud/github-actions/helm-publish@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ steps.semver.outputs.version }}
+          app-version: ${{ steps.semver.outputs.short-sha }}

--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -1,0 +1,63 @@
+# Adapted from https://github.com/stackhpc/azimuth/blob/master/.github/workflows/build-push-artifacts.yaml
+name: Publish artifacts
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        type: string
+        description: The ref to build.
+        required: true
+
+jobs:
+  build_push_images:
+    name: Build and push images
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - component: chat
+          - component: image-analysis
+    permissions:
+      contents: read
+      id-token: write         # needed for signing the images with GitHub OIDC Token
+      packages: write         # required for pushing container images
+      security-events: write  # required for pushing SARIF files
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get SemVer version for current commit
+        id: semver
+        uses: azimuth-cloud/github-actions/semver@master
+
+      - name: Calculate metadata for image
+        id: image-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/stackhpc/azimuth-llm-${{ matrix.component }}-ui
+          # Produce the branch name or tag and the SHA as tags
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=raw,value=${{ steps.semver.outputs.short-sha }}
+
+      - name: Build and push image
+        uses: azimuth-cloud/github-actions/docker-multiarch-build-push@master
+        with:
+          cache-key: ${{ matrix.component }}
+          context: ./web-apps/
+          file: ./web-apps/${{ matrix.component }}/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.image-meta.outputs.tags }}
+          labels: ${{ steps.image-meta.outputs.labels }}

--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -1,5 +1,5 @@
 # Adapted from https://github.com/stackhpc/azimuth/blob/master/.github/workflows/build-push-artifacts.yaml
-name: Publish artifacts
+name: Publish container images
 
 on:
   workflow_call:
@@ -27,7 +27,7 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ inputs.ref }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -24,17 +24,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: PR must be from a branch in the stackhpc/azimuth-llm repo
-        run: exit ${{ github.event.pull_request.head.repo.full_name == 'stackhpc/azimuth-llm' && '0' || '1' }}
+        run:  |
+          exit ${{ github.event.pull_request.head.repo.full_name == 'stackhpc/azimuth-llm' && '0' || '1' }}
 
-  publish_artifacts:
+  publish_images:
     needs: [fail_on_remote]
-    uses: ./.github/workflows/build-push-artifacts.yml
+    uses: ./.github/workflows/build-push-images.yml
     with:
       ref: ${{ github.event.pull_request.head.sha }}
     secrets: inherit
 
   chart_validation:
-    needs: [publish_artifacts]
+    needs: [publish_images]
     runs-on: ubuntu-latest
     env:
       CLUSTER_NAME: chart-testing
@@ -74,3 +75,9 @@ jobs:
       - name: Run chart install and test
         run: ct install --config ct.yaml
 
+  publish_charts:
+    needs: [chart_validation]
+    uses: ./.github/workflows/build-push-charts.yml
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}
+    secrets: inherit

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,7 +1,7 @@
 name: Check for dependency updates
 on:
   schedule:
-    - cron: "0 9 * * *"
+    - cron: "0 9 * * 0"
   workflow_dispatch:
 jobs:
   check_for_update:
@@ -33,7 +33,7 @@ jobs:
           git config user.name "${{ github.actor }}"
 
           # Get latest vLLM release tag and replace it in various places
-          CHART_VALUES=chart/values.yaml
+          CHART_VALUES=charts/azimuth-llm/values.yaml
           # Export vars so that they can be used by yq's strenv function
           export OLD_VLLM_TAG=$(yq '.api.image.version' $CHART_VALUES)
           export NEW_VLLM_TAG=$(curl -s https://api.github.com/repos/vllm-project/vllm/releases/latest | jq .tag_name | sed s/\"//g)


### PR DESCRIPTION
Separate image and chart build & push workflows so that we can run chart tests after image build but before publishing charts.