### PR TITLE
Fix error with long messages breaking for everyone

### DIFF
--- a/web-apps/chat/app.py
+++ b/web-apps/chat/app.py
@@ -70,7 +70,7 @@ def inference(latest_message, history):
         context = []
         if INCLUDE_SYSTEM_PROMPT:
             context.append(SystemMessage(content=settings.model_instruction))
-        else:
+        elif history and len(history) > 0:
             # Mimic system prompt by prepending it to first human message
             history[0]['content'] = f"{settings.model_instruction}\n\n{history[0]['content']}"
 


### PR DESCRIPTION
The error went like this:
User submits long message, backend returns BadRequestError, `INCLUDE_SYSTEM_PROMPT` gets flipped, chat history breaks for everyone.

These changes catch the error properly and tell the user to refresh the page.