### PR TITLE
Switch to pull_request workflow trigger

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -2,7 +2,7 @@
 name: Test pull request
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize


### PR DESCRIPTION
We don't need workflows to run in context of main branch (i.e. pull_request_target trigger) since the workflows don't have access to any secrets. Using pull_request_target just makes it more tedious to test changes to the workflows.